### PR TITLE
Add API Route and Handler For Topic Claim Button

### DIFF
--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -170,6 +170,12 @@ TopicObject:
           items:
             type: string
             description: HTML injected into the theme
+        claimerUid:
+          type: number
+          nullable: true
+        claimerUsername:
+          type: string
+          nullable: true
     - type: object
       description: Optional properties that may or may not be present (except for `tid`, which is always present, and is only here as a hack to pass validation)
       properties:
@@ -223,6 +229,7 @@ TopicObjectSlim:
           type: number
         claimerUid:
           type: number
+          nullable: true
         titleRaw:
           type: string
         locked:

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -1,6 +1,8 @@
 'use strict';
 
 
+console.log('================================');
+
 define('forum/topic', [
 	'forum/infinitescroll',
 	'forum/topic/threadTools',
@@ -53,6 +55,7 @@ define('forum/topic', [
 
 		postTools.init(tid);
 		threadTools.init(tid, $('.topic'));
+		console.log('initialized');
 		events.init();
 
 		sort.handleSort('topicPostSort', 'topic/' + ajaxify.data.slug);

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -55,7 +55,6 @@ define('forum/topic', [
 
 		postTools.init(tid);
 		threadTools.init(tid, $('.topic'));
-		console.log('initialized');
 		events.init();
 
 		sort.handleSort('topicPostSort', 'topic/' + ajaxify.data.slug);

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -51,6 +51,11 @@ define('forum/topic/threadTools', [
 			return false;
 		});
 
+		topicContainer.on('click', '[component="topic/claim"]', function () {
+			topicCommand('put', '/claim', 'claim');
+			return false;
+		});
+
 		topicContainer.on('click', '[component="topic/pin"]', function () {
 			topicCommand('put', '/pin', 'pin');
 			return false;
@@ -222,16 +227,26 @@ define('forum/topic/threadTools', [
 		});
 	}
 
+	// code assisted with chatGPT
 	function topicCommand(method, path, command, onComplete) {
 		if (!onComplete) {
-			onComplete = function () {};
+			onComplete = function () { };
 		}
 		const tid = ajaxify.data.tid;
 		const body = {};
 		const execute = function (ok) {
 			if (ok) {
 				api[method](`/topics/${tid}${path}`, body)
-					.then(onComplete)
+					.then(function () {
+						if (command === 'claim') {
+							ThreadTools.setClaimedState({
+								tid: tid,
+								claimerUid: app.user.uid,
+								claimerUsername: app.user.username,
+							});
+						}
+						onComplete();
+					})
 					.catch(alerts.error);
 			}
 		};
@@ -241,6 +256,10 @@ define('forum/topic/threadTools', [
 			case 'restore':
 			case 'purge':
 				bootbox.confirm(`[[topic:thread-tools.${command}-confirm]]`, execute);
+				break;
+
+			case 'claim':
+				execute(true);
 				break;
 
 			case 'pin':
@@ -353,6 +372,19 @@ define('forum/topic/threadTools', [
 		posts.addTopicEvents(data.events);
 	};
 
+	ThreadTools.setClaimedState = function (data) {
+		const threadEl = components.get('topic');
+		if (parseInt(data.tid, 10) !== parseInt(threadEl.attr('data-tid'), 10)) {
+			return;
+		}
+
+		const claimButton = threadEl.find('[component="topic/claim"]');
+		claimButton.prop('disabled', true).text(`Claimed by ${data.claimerUsername}`);
+	};
+
+	socket.on('event:topic_claimed', function (data) {
+		ThreadTools.setClaimedState(data);
+	});
 
 	ThreadTools.setPinnedState = function (data) {
 		const threadEl = components.get('topic');

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -18,8 +18,6 @@ define('forum/topic/threadTools', [
 	ThreadTools.init = function (tid, topicContainer) {
 		renderMenu(topicContainer);
 
-		console.log('hello running');
-
 		$('.topic-main-buttons [title]').tooltip({
 			container: '#content',
 			animation: false,
@@ -54,7 +52,6 @@ define('forum/topic/threadTools', [
 		});
 
 		topicContainer.on('click', '[component="topic/claim"]', function () {
-			console.log('started');
 			topicCommand('put', '/claim', 'claim');
 			return false;
 		});
@@ -70,7 +67,6 @@ define('forum/topic/threadTools', [
 		});
 
 		topicContainer.on('click', '[component="topic/mark-unread"]', function () {
-			console.log('unread');
 			topicCommand('del', '/read', undefined, () => {
 				if (app.previousUrl && !app.previousUrl.match('^/topic')) {
 					ajaxify.go(app.previousUrl, function () {
@@ -146,7 +142,6 @@ define('forum/topic/threadTools', [
 		});
 
 		topicContainer.on('click', '[component="topic/following"]', function () {
-			console.log('follow');
 			changeWatching('follow');
 		});
 		topicContainer.on('click', '[component="topic/not-following"]', function () {
@@ -239,7 +234,6 @@ define('forum/topic/threadTools', [
 		}
 		const tid = ajaxify.data.tid;
 		const body = {};
-		console.log(`/topics/${tid}${path}`);
 		const execute = function (ok) {
 			if (ok) {
 				api[method](`/topics/${tid}${path}`, body)

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -18,6 +18,8 @@ define('forum/topic/threadTools', [
 	ThreadTools.init = function (tid, topicContainer) {
 		renderMenu(topicContainer);
 
+		console.log('hello running');
+
 		$('.topic-main-buttons [title]').tooltip({
 			container: '#content',
 			animation: false,
@@ -66,7 +68,14 @@ define('forum/topic/threadTools', [
 			return false;
 		});
 
+		$(document).on('click', '[component="topic/claim"]', function () {
+			console.log('started');
+			topicCommand('put', '/claim', 'claim');
+			return false;
+		});
+
 		topicContainer.on('click', '[component="topic/mark-unread"]', function () {
+			console.log('unread');
 			topicCommand('del', '/read', undefined, () => {
 				if (app.previousUrl && !app.previousUrl.match('^/topic')) {
 					ajaxify.go(app.previousUrl, function () {
@@ -234,6 +243,7 @@ define('forum/topic/threadTools', [
 		}
 		const tid = ajaxify.data.tid;
 		const body = {};
+		console.log(`/topics/${tid}${path}`);
 		const execute = function (ok) {
 			if (ok) {
 				api[method](`/topics/${tid}${path}`, body)

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -54,6 +54,7 @@ define('forum/topic/threadTools', [
 		});
 
 		topicContainer.on('click', '[component="topic/claim"]', function () {
+			console.log('started');
 			topicCommand('put', '/claim', 'claim');
 			return false;
 		});
@@ -65,12 +66,6 @@ define('forum/topic/threadTools', [
 
 		topicContainer.on('click', '[component="topic/unpin"]', function () {
 			topicCommand('del', '/pin', 'unpin');
-			return false;
-		});
-
-		$(document).on('click', '[component="topic/claim"]', function () {
-			console.log('started');
-			topicCommand('put', '/claim', 'claim');
 			return false;
 		});
 
@@ -151,6 +146,7 @@ define('forum/topic/threadTools', [
 		});
 
 		topicContainer.on('click', '[component="topic/following"]', function () {
+			console.log('follow');
 			changeWatching('follow');
 		});
 		topicContainer.on('click', '[component="topic/not-following"]', function () {

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -137,7 +137,7 @@ topicsAPI.claim = async function (caller, { tid }) {
 
 	// start websocket event to notify other clients
 	websockets.in(`topic_${tid}`).emit('event:topic_claimed', {
-		tid: tid,
+		tid,
 		claimerUid: caller.uid,
 		claimerUsername: caller.username,
 	});

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -117,6 +117,34 @@ topicsAPI.reply = async function (caller, data) {
 	return postObj[0];
 };
 
+topicsAPI.claim = async function (caller, { tid }) {
+	// check if topic exists
+	const topicData = await topics.get(tid);
+	if (!topicData) {
+		throw new Error('[[error:no-topic]]');
+	}
+
+	// check if topic is claimed
+	if (topicData.claimerUid) {
+		throw new Error('[[error:topic-already-claimed]]');
+	}
+
+	// claim the topic
+	await topics.setTopicFields(tid, {
+		claimerUid: caller.uid,
+		claimerUsername: caller.username,
+	});
+
+	// start websocket event to notify other clients
+	websockets.in(`topic_${tid}`).emit('event:topic_claimed', {
+		tid: tid,
+		claimerUid: caller.uid,
+		claimerUsername: caller.username,
+	});
+
+	return { success: true, claimerUid: caller.uid, claimerUsername: caller.username };
+};
+
 topicsAPI.delete = async function (caller, data) {
 	await doTopicAction('delete', 'event:topic_deleted', caller, {
 		tids: data.tids,

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -136,6 +136,16 @@ topicsController.get = async function getTopic(req, res, next) {
 		rel.href = `${url}/topic/${topicData.slug}${rel.href}`;
 		res.locals.linkTags.push(rel);
 	});
+
+	if (topicData.claimerUid && topicData.claimerUid !== '0') {
+		// Get the claimer's username if the topic is claimed
+		const claimer = await user.getUserFields(topicData.claimerUid, ['username']);
+		topicData.claimerUsername = claimer.username;
+	} else {
+		// If no claimer, set the username to null
+		topicData.claimerUsername = null;
+	}
+
 	res.render('topic', topicData);
 };
 

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -70,7 +70,7 @@ Topics.pin = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
-Topics.claim = async (req, res) => {
+Topics.claimTopic = async (req, res) => {
 	await api.topics.claim(req, { tids: [req.params.tid] });
 	helpers.formatApiResponse(200, res);
 };

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -70,6 +70,11 @@ Topics.pin = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Topics.claim = async (req, res) => {
+	await api.topics.claim(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
 Topics.unpin = async (req, res) => {
 	await api.topics.unpin(req, { tids: [req.params.tid] });
 	helpers.formatApiResponse(200, res);

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -32,7 +32,7 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.ignore);
 	setupApiRoute(router, 'delete', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.unfollow); // intentional, unignore == unfollow
 
-	setupApiRoute(router, 'put', '/:tid/claim', [middleware.ensureLoggedIn, middleware.isTA], controllers.topics.claim);
+	setupApiRoute(router, 'put', '/:tid/claim', [...middlewares, middleware.assert.topic], controllers.write.topics.claimTopic);
 
 	setupApiRoute(router, 'put', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.updateTags);
 	setupApiRoute(router, 'patch', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.addTags);

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -32,6 +32,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.ignore);
 	setupApiRoute(router, 'delete', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.unfollow); // intentional, unignore == unfollow
 
+	setupApiRoute(router, 'put', '/:tid/claim', [middleware.ensureLoggedIn, middleware.isTA], controllers.topics.claim);
+
 	setupApiRoute(router, 'put', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.updateTags);
 	setupApiRoute(router, 'patch', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.addTags);
 	setupApiRoute(router, 'delete', '/:tid/tags', [...middlewares, middleware.assert.topic], controllers.write.topics.deleteTags);

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -32,7 +32,7 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.ignore);
 	setupApiRoute(router, 'delete', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.unfollow); // intentional, unignore == unfollow
 
-	setupApiRoute(router, 'put', '/:tid/claim', [...middlewares, middleware.assert.topic], controllers.write.topics.claimTopic);
+	setupApiRoute(router, 'put', '/:tid/claim', [...middlewares], controllers.write.topics.claimTopic);
 
 	setupApiRoute(router, 'put', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.updateTags);
 	setupApiRoute(router, 'patch', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.addTags);

--- a/test/api.js
+++ b/test/api.js
@@ -615,54 +615,46 @@ describe('API', async () => {
 		// Compare the schema to the response
 		required.forEach((prop) => {
 			if (schema.hasOwnProperty(prop)) {
-				if (schema[prop].nullable === true) {
-					if (response.hasOwnProperty(prop)) {
-						// eslint-disable-next-line valid-typeof
-						assert(response[prop] === null || typeof response[prop] === schema[prop].type,
-							`"${prop}" should be null or of type ${schema[prop].type} (path: ${method} ${path}, context: ${context})`);
-					}
-				} else {
-					assert(response.hasOwnProperty(prop), `"${prop}" is a required property (path: ${method} ${path}, context: ${context})`);
+				assert(response.hasOwnProperty(prop), `"${prop}" is a required property (path: ${method} ${path}, context: ${context})`);
 
-					// Don't proceed with type-check if the value could possibly be unset (nullable: true, in spec)
-					if (response[prop] === null && schema[prop].nullable === true) {
-						return;
-					}
+				// Don't proceed with type-check if the value could possibly be unset (nullable: true, in spec)
+				if (response[prop] === null && schema[prop].nullable === true) {
+					return;
+				}
 
-					// Therefore, if the value is actually null, that's a problem (nullable is probably missing)
-					assert(response[prop] !== null, `"${prop}" was null, but schema does not specify it to be a nullable property (path: ${method} ${path}, context: ${context})`);
+				// Therefore, if the value is actually null, that's a problem (nullable is probably missing)
+				assert(response[prop] !== null, `"${prop}" was null, but schema does not specify it to be a nullable property (path: ${method} ${path}, context: ${context})`);
 
-					switch (schema[prop].type) {
-						case 'string':
-							assert.strictEqual(typeof response[prop], 'string', `"${prop}" was expected to be a string, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
-							break;
-						case 'boolean':
-							assert.strictEqual(typeof response[prop], 'boolean', `"${prop}" was expected to be a boolean, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
-							break;
-						case 'object':
-							assert.strictEqual(typeof response[prop], 'object', `"${prop}" was expected to be an object, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
-							compare(schema[prop], response[prop], method, path, context ? [context, prop].join('.') : prop);
-							break;
-						case 'array':
-							assert.strictEqual(Array.isArray(response[prop]), true, `"${prop}" was expected to be an array, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+				switch (schema[prop].type) {
+					case 'string':
+						assert.strictEqual(typeof response[prop], 'string', `"${prop}" was expected to be a string, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+						break;
+					case 'boolean':
+						assert.strictEqual(typeof response[prop], 'boolean', `"${prop}" was expected to be a boolean, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+						break;
+					case 'object':
+						assert.strictEqual(typeof response[prop], 'object', `"${prop}" was expected to be an object, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+						compare(schema[prop], response[prop], method, path, context ? [context, prop].join('.') : prop);
+						break;
+					case 'array':
+						assert.strictEqual(Array.isArray(response[prop]), true, `"${prop}" was expected to be an array, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
 
-							if (schema[prop].items) {
-								// Ensure the array items have a schema defined
-								assert(schema[prop].items.type || schema[prop].items.allOf || schema[prop].items.anyOf || schema[prop].items.oneOf, `"${prop}" is defined to be an array, but its items have no schema defined (path: ${method} ${path}, context: ${context})`);
+						if (schema[prop].items) {
+							// Ensure the array items have a schema defined
+							assert(schema[prop].items.type || schema[prop].items.allOf || schema[prop].items.anyOf || schema[prop].items.oneOf, `"${prop}" is defined to be an array, but its items have no schema defined (path: ${method} ${path}, context: ${context})`);
 
-								// Compare types
-								if (schema[prop].items.type === 'object' || Array.isArray(schema[prop].items.allOf || schema[prop].items.anyOf || schema[prop].items.oneOf)) {
-									response[prop].forEach((res) => {
-										compare(schema[prop].items, res, method, path, context ? [context, prop].join('.') : prop);
-									});
-								} else if (response[prop].length) { // for now
-									response[prop].forEach((item) => {
-										assert.strictEqual(typeof item, schema[prop].items.type, `"${prop}" should have ${schema[prop].items.type} items, but found ${typeof items} instead (path: ${method} ${path}, context: ${context})`);
-									});
-								}
+							// Compare types
+							if (schema[prop].items.type === 'object' || Array.isArray(schema[prop].items.allOf || schema[prop].items.anyOf || schema[prop].items.oneOf)) {
+								response[prop].forEach((res) => {
+									compare(schema[prop].items, res, method, path, context ? [context, prop].join('.') : prop);
+								});
+							} else if (response[prop].length) { // for now
+								response[prop].forEach((item) => {
+									assert.strictEqual(typeof item, schema[prop].items.type, `"${prop}" should have ${schema[prop].items.type} items, but found ${typeof items} instead (path: ${method} ${path}, context: ${context})`);
+								});
 							}
-							break;
-					}
+						}
+						break;
 				}
 			}
 		});

--- a/test/api.js
+++ b/test/api.js
@@ -615,46 +615,54 @@ describe('API', async () => {
 		// Compare the schema to the response
 		required.forEach((prop) => {
 			if (schema.hasOwnProperty(prop)) {
-				assert(response.hasOwnProperty(prop), `"${prop}" is a required property (path: ${method} ${path}, context: ${context})`);
+				if (schema[prop].nullable === true) {
+					if (response.hasOwnProperty(prop)) {
+						// eslint-disable-next-line valid-typeof
+						assert(response[prop] === null || typeof response[prop] === schema[prop].type,
+							`"${prop}" should be null or of type ${schema[prop].type} (path: ${method} ${path}, context: ${context})`);
+					}
+				} else {
+					assert(response.hasOwnProperty(prop), `"${prop}" is a required property (path: ${method} ${path}, context: ${context})`);
 
-				// Don't proceed with type-check if the value could possibly be unset (nullable: true, in spec)
-				if (response[prop] === null && schema[prop].nullable === true) {
-					return;
-				}
+					// Don't proceed with type-check if the value could possibly be unset (nullable: true, in spec)
+					if (response[prop] === null && schema[prop].nullable === true) {
+						return;
+					}
 
-				// Therefore, if the value is actually null, that's a problem (nullable is probably missing)
-				assert(response[prop] !== null, `"${prop}" was null, but schema does not specify it to be a nullable property (path: ${method} ${path}, context: ${context})`);
+					// Therefore, if the value is actually null, that's a problem (nullable is probably missing)
+					assert(response[prop] !== null, `"${prop}" was null, but schema does not specify it to be a nullable property (path: ${method} ${path}, context: ${context})`);
 
-				switch (schema[prop].type) {
-					case 'string':
-						assert.strictEqual(typeof response[prop], 'string', `"${prop}" was expected to be a string, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
-						break;
-					case 'boolean':
-						assert.strictEqual(typeof response[prop], 'boolean', `"${prop}" was expected to be a boolean, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
-						break;
-					case 'object':
-						assert.strictEqual(typeof response[prop], 'object', `"${prop}" was expected to be an object, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
-						compare(schema[prop], response[prop], method, path, context ? [context, prop].join('.') : prop);
-						break;
-					case 'array':
-						assert.strictEqual(Array.isArray(response[prop]), true, `"${prop}" was expected to be an array, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+					switch (schema[prop].type) {
+						case 'string':
+							assert.strictEqual(typeof response[prop], 'string', `"${prop}" was expected to be a string, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+							break;
+						case 'boolean':
+							assert.strictEqual(typeof response[prop], 'boolean', `"${prop}" was expected to be a boolean, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+							break;
+						case 'object':
+							assert.strictEqual(typeof response[prop], 'object', `"${prop}" was expected to be an object, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+							compare(schema[prop], response[prop], method, path, context ? [context, prop].join('.') : prop);
+							break;
+						case 'array':
+							assert.strictEqual(Array.isArray(response[prop]), true, `"${prop}" was expected to be an array, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
 
-						if (schema[prop].items) {
-							// Ensure the array items have a schema defined
-							assert(schema[prop].items.type || schema[prop].items.allOf || schema[prop].items.anyOf || schema[prop].items.oneOf, `"${prop}" is defined to be an array, but its items have no schema defined (path: ${method} ${path}, context: ${context})`);
+							if (schema[prop].items) {
+								// Ensure the array items have a schema defined
+								assert(schema[prop].items.type || schema[prop].items.allOf || schema[prop].items.anyOf || schema[prop].items.oneOf, `"${prop}" is defined to be an array, but its items have no schema defined (path: ${method} ${path}, context: ${context})`);
 
-							// Compare types
-							if (schema[prop].items.type === 'object' || Array.isArray(schema[prop].items.allOf || schema[prop].items.anyOf || schema[prop].items.oneOf)) {
-								response[prop].forEach((res) => {
-									compare(schema[prop].items, res, method, path, context ? [context, prop].join('.') : prop);
-								});
-							} else if (response[prop].length) { // for now
-								response[prop].forEach((item) => {
-									assert.strictEqual(typeof item, schema[prop].items.type, `"${prop}" should have ${schema[prop].items.type} items, but found ${typeof items} instead (path: ${method} ${path}, context: ${context})`);
-								});
+								// Compare types
+								if (schema[prop].items.type === 'object' || Array.isArray(schema[prop].items.allOf || schema[prop].items.anyOf || schema[prop].items.oneOf)) {
+									response[prop].forEach((res) => {
+										compare(schema[prop].items, res, method, path, context ? [context, prop].join('.') : prop);
+									});
+								} else if (response[prop].length) { // for now
+									response[prop].forEach((item) => {
+										assert.strictEqual(typeof item, schema[prop].items.type, `"${prop}" should have ${schema[prop].items.type} items, but found ${typeof items} instead (path: ${method} ${path}, context: ${context})`);
+									});
+								}
 							}
-						}
-						break;
+							break;
+					}
 				}
 			}
 		});


### PR DESCRIPTION
This change adds most of the code for the claim button's basic control flow, starting from the API route to the handler, the helpers for the controller function, and ultimately the logic of setting topic fields within the database.

Server-side
- Added a new API endpoint `PUT /topics/:tid/claim` in `src/routes/write/topics.js`. 
- Added the `Topics.claim` controller function in `src/controllers/write/topics.js`, which calls `topicsAPI.claim` containing the claim logic in `src/api/topics.js`. 
- Added a WebSocket event `event:topic_claimed` is emitted to notify all connected clients when a topic is claimed.

Client-side
- Added the claim button functionality in `public/src/client/topic/threadTools.js`. 
- Added an event handler within `ThreadTools.init` that uses the existing `topicCommand` function to handle a new 'claim' action when the claim button is clicked. 
- Updated UI with`ThreadTools.setClaimedState`, which disables the claim button and displays the claimer's username. 
- Added a WebSocket listener for `event:topic_claimed` was added to handle real-time updates, ensuring all users immediately see the updated claim status.

Codebase Findings
- The code is essentially a standard web app that uses client calls for buttons or changes to the UI to access the server-side API.
- Any handling done by the user side provokes a WebSocket to handle any changes to other users and is used here to update other clients of the changed button.

Potential Features
- The button could be locked with middleware to restrict access to authenticated TAs (`middleware.ensureLoggedIn and middleware.isTA`)