### PR TITLE
Modify Topic Schema Fields

### DIFF
--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -221,6 +221,8 @@ TopicObjectSlim:
           type: number
         deleterUid:
           type: number
+        claimerUid:
+          type: number
         titleRaw:
           type: string
         locked:

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -21,7 +21,6 @@ module.exports = function (Topics) {
 			return [];
 		}
 
-		// Add 'claimerUid' and 'claimerUsername' to the fields if not already included
 		// if (!fields.includes('claimerUid')) {
 		// 	fields.push('claimerUid');
 		// }

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -21,14 +21,6 @@ module.exports = function (Topics) {
 			return [];
 		}
 
-		// if (!fields.includes('claimerUid')) {
-		// 	fields.push('claimerUid');
-		// }
-
-		// if (!fields.includes('claimerUsername')) {
-		// 	fields.push('claimerUsername');
-		// }
-
 		// "scheduled" is derived from "timestamp"
 		if (fields.includes('scheduled') && !fields.includes('timestamp')) {
 			fields.push('timestamp');

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -12,7 +12,7 @@ const intFields = [
 	'tid', 'cid', 'uid', 'mainPid', 'postcount',
 	'viewcount', 'postercount', 'deleted', 'locked', 'pinned',
 	'pinExpiry', 'timestamp', 'upvotes', 'downvotes', 'lastposttime',
-	'deleterUid',
+	'deleterUid', 'claimerUid',
 ];
 
 module.exports = function (Topics) {
@@ -20,6 +20,15 @@ module.exports = function (Topics) {
 		if (!Array.isArray(tids) || !tids.length) {
 			return [];
 		}
+
+		// // Add 'claimerUid' and 'claimerUsername' to the fields if not already included
+		// if (!fields.includes('claimerUid')) {
+		// 	fields.push('claimerUid');
+		// }
+
+		// if (!fields.includes('claimerUsername')) {
+		// 	fields.push('claimerUsername');
+		// }
 
 		// "scheduled" is derived from "timestamp"
 		if (fields.includes('scheduled') && !fields.includes('timestamp')) {

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -21,7 +21,7 @@ module.exports = function (Topics) {
 			return [];
 		}
 
-		// // Add 'claimerUid' and 'claimerUsername' to the fields if not already included
+		// Add 'claimerUid' and 'claimerUsername' to the fields if not already included
 		// if (!fields.includes('claimerUid')) {
 		// 	fields.push('claimerUid');
 		// }


### PR DESCRIPTION
Modified the TopicObject schema to have two new non-required fields: `claimerUid` and `claimerUsername`. This will provide the information needed for that claim button to display the user as well as the status of the topic. If the topic is claimed the field will be non-null with the `claimerUid`, but if not claimed, will be a null field.