### PR TITLE
Adding logic to sort the posts by popularity. Still need to be tested

### DIFF
--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -98,8 +98,39 @@ module.exports = function (Categories) {
 			most_votes: `cid:${cid}:tids:votes`,
 			most_views: `cid:${cid}:tids:views`,
 		};
+		let set;
+		if (sort === 'popularity') {
+			const voteSortedSet = `cid:${cid}:tids:votes`;
+			const createSortedSet = `cid:${cid}:tids:create`;
+			const postIdsWithScores = await db.getSortedSetRangeWithScores(voteSortedSet, 0, -1);
+			const tempSortedSet = `cid:${cid}:tids:popular`;
+			await db.delete(tempSortedSet); 
+			const recentIdsWithScores = await db.getSortedSetRangeWithScores(createSortedSet, 0, -1);
 
-		let set = sortToSet.hasOwnProperty(sort) ? sortToSet[sort] : `cid:${cid}:tids`;
+			const currentTime = Date.now();
+			for (let i = 0; i < postIdsWithScores.length; i += 1) {
+				const postId = postIdsWithScores[i];
+				const votes = postIdsWithScores[i];
+	
+				const result = recentIdsWithScores.find(item => item.value === postId['value']);
+				const postCreationTime = result ? result.score : null;
+				if (!postCreationTime) {
+					continue;
+				}
+
+				const timeSinceCreation = (currentTime - postCreationTime) /3600000; 
+				const votes_num = votes['score'] + 1;
+				const time = Math.pow(timeSinceCreation+2,1.8)
+				const score = votes_num / time;
+
+				await db.sortedSetAdd(tempSortedSet, score, postId['value']);
+			}
+
+
+			set = tempSortedSet;
+		}else{
+			set = sortToSet.hasOwnProperty(sort) ? sortToSet[sort] : `cid:${cid}:tids`;
+		}
 
 		if (data.tag) {
 			if (Array.isArray(data.tag)) {

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -21,7 +21,7 @@ const categoryController = module.exports;
 const url = nconf.get('url');
 const relative_path = nconf.get('relative_path');
 const validSorts = [
-	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views',
+	'recently_replied', 'recently_created', 'most_posts', 'most_votes', 'most_views', 'popularity',
 ];
 
 categoryController.get = async function (req, res, next) {

--- a/src/views/admin/settings/post.tpl
+++ b/src/views/admin/settings/post.tpl
@@ -20,6 +20,7 @@
 					<select id="categoryTopicSort" class="form-select" data-field="categoryTopicSort">
 						<option value="recently_replied">[[admin/settings/post:sorting.recently-replied]]</option>
 						<option value="recently_created">[[admin/settings/post:sorting.recently-created]]</option>
+						<option value="popularity">[[admin/settings/post:sorting.popularity]]</option>
 						<option value="most_posts">[[admin/settings/post:sorting.most-posts]]</option>
 						<option value="most_votes">[[admin/settings/post:sorting.most-votes]]</option>
 						<option value="most_views">[[admin/settings/post:sorting.most-views]]</option>


### PR DESCRIPTION
This change introduces new logic to sort posts by their popularity.
### Changes:
Modified the `Categories.buildTopicsSortedSet` function in `src/categories/topics.js`. When sorting by popularity, the function creates a temporary Redis sorted set. This set stores the score for each post, which is calculated based on an algorithm that considers the number of votes and the time since the post's creation. 
### Codebase Findings:
When any changes are made to a post, the app updates the corresponding Redis datasets. These datasets are then used when posts are requested to be sorted in specific ways, such as by votes, creation time, or popularity.
### Potential Issues:
This change has not yet been tested with a large number of posts. Creating a new Redis sorted set, where the score is dynamically calculated based on the number of votes and the time since creation, may become time-consuming as the dataset grows. 