### PR TITLE
Adding New Fields Into Username Data for Backend for Reputation

### DIFF
--- a/src/api/users.js
+++ b/src/api/users.js
@@ -34,7 +34,6 @@ usersAPI.create = async function (caller, data) {
 		throw new Error('[[error:invalid-data]]');
 	}
 	await hasAdminPrivilege(caller.uid, 'users');
-	console.log("printttttttttttt");
 	const uid = await user.create(data);
 	return await user.getUserData(uid);
 };
@@ -44,7 +43,6 @@ usersAPI.get = async (caller, { uid }) => {
 	if (!canView) {
 		throw new Error('[[error:no-privileges]]');
 	}
-	console.log("printttttttttttt");
 	const userData = await user.getUserData(uid);
 	return await user.hidePrivateData(userData, caller.uid);
 };
@@ -57,7 +55,6 @@ usersAPI.update = async function (caller, data) {
 	if (!data || !data.uid) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	console.log("printttttttttttt");
 	const oldUserData = await user.getUserFields(data.uid, ['email', 'username']);
 	if (!oldUserData || !oldUserData.username) {
 		throw new Error('[[error:invalid-data]]');
@@ -125,7 +122,6 @@ usersAPI.updateSettings = async function (caller, data) {
 	if (!caller.uid || !data || !data.settings) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	console.log("printttttttttttt");
 	const canEdit = await privileges.users.canEdit(caller.uid, data.uid);
 	if (!canEdit) {
 		throw new Error('[[error:no-privileges]]');
@@ -183,7 +179,6 @@ usersAPI.follow = async function (caller, data) {
 
 	const userData = await user.getUserFields(caller.uid, ['username', 'userslug']);
 	const { displayname } = userData;
-	console.log("printttttttttttt");
 	const notifObj = await notifications.create({
 		type: 'follow',
 		bodyShort: `[[notifications:user-started-following-you, ${displayname}]]`,

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -34,7 +34,7 @@ usersAPI.create = async function (caller, data) {
 		throw new Error('[[error:invalid-data]]');
 	}
 	await hasAdminPrivilege(caller.uid, 'users');
-
+	console.log("printttttttttttt");
 	const uid = await user.create(data);
 	return await user.getUserData(uid);
 };
@@ -44,6 +44,7 @@ usersAPI.get = async (caller, { uid }) => {
 	if (!canView) {
 		throw new Error('[[error:no-privileges]]');
 	}
+	console.log("printttttttttttt");
 	const userData = await user.getUserData(uid);
 	return await user.hidePrivateData(userData, caller.uid);
 };
@@ -56,7 +57,7 @@ usersAPI.update = async function (caller, data) {
 	if (!data || !data.uid) {
 		throw new Error('[[error:invalid-data]]');
 	}
-
+	console.log("printttttttttttt");
 	const oldUserData = await user.getUserFields(data.uid, ['email', 'username']);
 	if (!oldUserData || !oldUserData.username) {
 		throw new Error('[[error:invalid-data]]');
@@ -124,7 +125,7 @@ usersAPI.updateSettings = async function (caller, data) {
 	if (!caller.uid || !data || !data.settings) {
 		throw new Error('[[error:invalid-data]]');
 	}
-
+	console.log("printttttttttttt");
 	const canEdit = await privileges.users.canEdit(caller.uid, data.uid);
 	if (!canEdit) {
 		throw new Error('[[error:no-privileges]]');
@@ -182,7 +183,7 @@ usersAPI.follow = async function (caller, data) {
 
 	const userData = await user.getUserFields(caller.uid, ['username', 'userslug']);
 	const { displayname } = userData;
-
+	console.log("printttttttttttt");
 	const notifObj = await notifications.create({
 		type: 'follow',
 		bodyShort: `[[notifications:user-started-following-you, ${displayname}]]`,

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -12,7 +12,8 @@ const utils = require('../utils');
 const relative_path = nconf.get('relative_path');
 
 const intFields = [
-	'uid', 'postcount', 'topiccount', 'reputation', 'profileviews',
+	'uid', 'postcount', 'topiccount', 'reputation', 'reputationSilver',
+	'reputationGold', 'profileviews',
 	'banned', 'banned:expire', 'email:confirmed', 'joindate', 'lastonline',
 	'lastqueuetime', 'lastposttime', 'followingCount', 'followerCount',
 	'blocksCount', 'passwordExpiry', 'mutedUntil',
@@ -23,6 +24,7 @@ module.exports = function (User) {
 		'uid', 'username', 'userslug', 'email', 'email:confirmed', 'joindate',
 		'lastonline', 'picture', 'icon:bgColor', 'fullname', 'location', 'birthday', 'website',
 		'aboutme', 'signature', 'uploadedpicture', 'profileviews', 'reputation',
+		'reputationSilver', 'reputationGold',
 		'postcount', 'topiccount', 'lastposttime', 'banned', 'banned:expire',
 		'status', 'flags', 'followerCount', 'followingCount', 'cover:url',
 		'cover:position', 'groupTitle', 'mutedUntil', 'mutedReason',
@@ -40,7 +42,9 @@ module.exports = function (User) {
 		groupTitle: '',
 		groupTitleArray: [],
 		status: 'offline',
-		reputation: 0,
+		//reputation: 100,
+		reputationSilver: true,
+		reputationGold: true,
 		'email:confirmed': 0,
 	};
 
@@ -50,7 +54,7 @@ module.exports = function (User) {
 		if (!Array.isArray(uids) || !uids.length) {
 			return [];
 		}
-
+		console.log("userfields");
 		uids = uids.map(uid => (isNaN(uid) ? 0 : parseInt(uid, 10)));
 
 		const fieldsToRemove = [];
@@ -81,6 +85,7 @@ module.exports = function (User) {
 				user.oldUid = uniqueUids[index];
 			}
 		});
+		
 		await modifyUserData(result.users, fields, fieldsToRemove);
 		return uidsToUsers(uids, uniqueUids, result.users);
 	};
@@ -200,6 +205,15 @@ module.exports = function (User) {
 			}
 
 			db.parseIntFields(user, intFields, requestedFields);
+			
+			user.reputationSilver = true;
+			if (user.hasOwnProperty('reputationSilver')) {
+				user.reputationSilver = (user.reputation >= 500);
+			}
+			
+			if (user.hasOwnProperty('reputationGold')) {
+				user.reputationGold = (user.reputation >= 2000);
+			}
 
 			if (user.hasOwnProperty('username')) {
 				parseDisplayName(user, uidToSettings);

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -54,7 +54,6 @@ module.exports = function (User) {
 		if (!Array.isArray(uids) || !uids.length) {
 			return [];
 		}
-		console.log("userfields");
 		uids = uids.map(uid => (isNaN(uid) ? 0 : parseInt(uid, 10)));
 
 		const fieldsToRemove = [];

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -83,7 +83,7 @@ module.exports = function (User) {
 				user.oldUid = uniqueUids[index];
 			}
 		});
-		
+
 		await modifyUserData(result.users, fields, fieldsToRemove);
 		return uidsToUsers(uids, uniqueUids, result.users);
 	};
@@ -203,12 +203,12 @@ module.exports = function (User) {
 			}
 
 			db.parseIntFields(user, intFields, requestedFields);
-			
+
 			user.reputationSilver = true;
 			if (user.hasOwnProperty('reputationSilver')) {
 				user.reputationSilver = (user.reputation >= 500);
 			}
-			
+
 			if (user.hasOwnProperty('reputationGold')) {
 				user.reputationGold = (user.reputation >= 2000);
 			}

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -42,7 +42,6 @@ module.exports = function (User) {
 		groupTitle: '',
 		groupTitleArray: [],
 		status: 'offline',
-		//reputation: 100,
 		reputationSilver: true,
 		reputationGold: true,
 		'email:confirmed': 0,

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -14,12 +14,10 @@ const plugins = require('../plugins');
 
 module.exports = function (User) {
 	User.updateProfile = async function (uid, data, extraFields) {
-		console.log("printttttttttttt");
 		let fields = [
 			'username', 'email', 'fullname', 'website', 'location',
 			'groupTitle', 'birthday', 'signature', 'aboutme',
 		];
-		console.log("printttttttttttt");
 		if (Array.isArray(extraFields)) {
 			fields = _.uniq(fields.concat(extraFields));
 		}
@@ -101,7 +99,6 @@ module.exports = function (User) {
 		if (!data.username) {
 			return;
 		}
-		console.log("printttttttttttt");
 		data.username = data.username.trim();
 
 		let userData;

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -14,10 +14,12 @@ const plugins = require('../plugins');
 
 module.exports = function (User) {
 	User.updateProfile = async function (uid, data, extraFields) {
+		console.log("printttttttttttt");
 		let fields = [
 			'username', 'email', 'fullname', 'website', 'location',
 			'groupTitle', 'birthday', 'signature', 'aboutme',
 		];
+		console.log("printttttttttttt");
 		if (Array.isArray(extraFields)) {
 			fields = _.uniq(fields.concat(extraFields));
 		}
@@ -33,7 +35,7 @@ module.exports = function (User) {
 		});
 		fields = result.fields;
 		data = result.data;
-
+		
 		await validateData(uid, data);
 
 		const oldData = await User.getUserFields(updateUid, fields);
@@ -99,6 +101,7 @@ module.exports = function (User) {
 		if (!data.username) {
 			return;
 		}
+		console.log("printttttttttttt");
 		data.username = data.username.trim();
 
 		let userData;

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -33,7 +33,7 @@ module.exports = function (User) {
 		});
 		fields = result.fields;
 		data = result.data;
-		
+
 		await validateData(uid, data);
 
 		const oldData = await User.getUserFields(updateUid, fields);


### PR DESCRIPTION
I added new fields into the username data for the backend for reputation, including reputationSilver and reputationGold, which check whether the reputation count is above 500 or 2000 respectively. This is used so that the frontend can access the values easier, since the frontend tpl cannot directly compare numbers to create a boolean. The way this is done is by just going to the place the user class is defined and adding fields and changing some methods.