### PR TITLE
Revert "Revert "Add API Route and Handler For Topic Claim Button""

### DIFF
--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -170,6 +170,12 @@ TopicObject:
           items:
             type: string
             description: HTML injected into the theme
+        claimerUid:
+          type: number
+          nullable: true
+        claimerUsername:
+          type: string
+          nullable: true
     - type: object
       description: Optional properties that may or may not be present (except for `tid`, which is always present, and is only here as a hack to pass validation)
       properties:
@@ -223,6 +229,7 @@ TopicObjectSlim:
           type: number
         claimerUid:
           type: number
+          nullable: true
         titleRaw:
           type: string
         locked:

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -1,6 +1,8 @@
 'use strict';
 
 
+console.log('================================');
+
 define('forum/topic', [
 	'forum/infinitescroll',
 	'forum/topic/threadTools',

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -51,6 +51,11 @@ define('forum/topic/threadTools', [
 			return false;
 		});
 
+		topicContainer.on('click', '[component="topic/claim"]', function () {
+			topicCommand('put', '/claim', 'claim');
+			return false;
+		});
+
 		topicContainer.on('click', '[component="topic/pin"]', function () {
 			topicCommand('put', '/pin', 'pin');
 			return false;
@@ -222,16 +227,26 @@ define('forum/topic/threadTools', [
 		});
 	}
 
+	// code assisted with chatGPT
 	function topicCommand(method, path, command, onComplete) {
 		if (!onComplete) {
-			onComplete = function () {};
+			onComplete = function () { };
 		}
 		const tid = ajaxify.data.tid;
 		const body = {};
 		const execute = function (ok) {
 			if (ok) {
 				api[method](`/topics/${tid}${path}`, body)
-					.then(onComplete)
+					.then(function () {
+						if (command === 'claim') {
+							ThreadTools.setClaimedState({
+								tid: tid,
+								claimerUid: app.user.uid,
+								claimerUsername: app.user.username,
+							});
+						}
+						onComplete();
+					})
 					.catch(alerts.error);
 			}
 		};
@@ -241,6 +256,10 @@ define('forum/topic/threadTools', [
 			case 'restore':
 			case 'purge':
 				bootbox.confirm(`[[topic:thread-tools.${command}-confirm]]`, execute);
+				break;
+
+			case 'claim':
+				execute(true);
 				break;
 
 			case 'pin':
@@ -353,6 +372,19 @@ define('forum/topic/threadTools', [
 		posts.addTopicEvents(data.events);
 	};
 
+	ThreadTools.setClaimedState = function (data) {
+		const threadEl = components.get('topic');
+		if (parseInt(data.tid, 10) !== parseInt(threadEl.attr('data-tid'), 10)) {
+			return;
+		}
+
+		const claimButton = threadEl.find('[component="topic/claim"]');
+		claimButton.prop('disabled', true).text(`Claimed by ${data.claimerUsername}`);
+	};
+
+	socket.on('event:topic_claimed', function (data) {
+		ThreadTools.setClaimedState(data);
+	});
 
 	ThreadTools.setPinnedState = function (data) {
 		const threadEl = components.get('topic');

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -117,6 +117,34 @@ topicsAPI.reply = async function (caller, data) {
 	return postObj[0];
 };
 
+topicsAPI.claim = async function (caller, { tid }) {
+	// check if topic exists
+	const topicData = await topics.get(tid);
+	if (!topicData) {
+		throw new Error('[[error:no-topic]]');
+	}
+
+	// check if topic is claimed
+	if (topicData.claimerUid) {
+		throw new Error('[[error:topic-already-claimed]]');
+	}
+
+	// claim the topic
+	await topics.setTopicFields(tid, {
+		claimerUid: caller.uid,
+		claimerUsername: caller.username,
+	});
+
+	// start websocket event to notify other clients
+	websockets.in(`topic_${tid}`).emit('event:topic_claimed', {
+		tid,
+		claimerUid: caller.uid,
+		claimerUsername: caller.username,
+	});
+
+	return { success: true, claimerUid: caller.uid, claimerUsername: caller.username };
+};
+
 topicsAPI.delete = async function (caller, data) {
 	await doTopicAction('delete', 'event:topic_deleted', caller, {
 		tids: data.tids,

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -136,6 +136,16 @@ topicsController.get = async function getTopic(req, res, next) {
 		rel.href = `${url}/topic/${topicData.slug}${rel.href}`;
 		res.locals.linkTags.push(rel);
 	});
+
+	if (topicData.claimerUid && topicData.claimerUid !== '0') {
+		// Get the claimer's username if the topic is claimed
+		const claimer = await user.getUserFields(topicData.claimerUid, ['username']);
+		topicData.claimerUsername = claimer.username;
+	} else {
+		// If no claimer, set the username to null
+		topicData.claimerUsername = null;
+	}
+
 	res.render('topic', topicData);
 };
 

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -70,6 +70,11 @@ Topics.pin = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Topics.claimTopic = async (req, res) => {
+	await api.topics.claim(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
 Topics.unpin = async (req, res) => {
 	await api.topics.unpin(req, { tids: [req.params.tid] });
 	helpers.formatApiResponse(200, res);

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -32,6 +32,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.ignore);
 	setupApiRoute(router, 'delete', '/:tid/ignore', [...middlewares, middleware.assert.topic], controllers.write.topics.unfollow); // intentional, unignore == unfollow
 
+	setupApiRoute(router, 'put', '/:tid/claim', [...middlewares], controllers.write.topics.claimTopic);
+
 	setupApiRoute(router, 'put', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.updateTags);
 	setupApiRoute(router, 'patch', '/:tid/tags', [...middlewares, middleware.checkRequired.bind(null, ['tags']), middleware.assert.topic], controllers.write.topics.addTags);
 	setupApiRoute(router, 'delete', '/:tid/tags', [...middlewares, middleware.assert.topic], controllers.write.topics.deleteTags);


### PR DESCRIPTION
This change adds most of the code for the claim button's basic control flow, starting from the API route to the handler, the helpers for the controller function, and ultimately the logic of setting topic fields within the database.

Server-side
- Added a new API endpoint `PUT /topics/:tid/claim` in `src/routes/write/topics.js`. 
- Added the `Topics.claim` controller function in `src/controllers/write/topics.js`, which calls `topicsAPI.claim` containing the claim logic in `src/api/topics.js`. 
- Added a WebSocket event `event:topic_claimed` is emitted to notify all connected clients when a topic is claimed.

Client-side
- Added the claim button functionality in `public/src/client/topic/threadTools.js`. 
- Added an event handler within `ThreadTools.init` that uses the existing `topicCommand` function to handle a new 'claim' action when the claim button is clicked. 
- Updated UI with`ThreadTools.setClaimedState`, which disables the claim button and displays the claimer's username. 
- Added a WebSocket listener for `event:topic_claimed` was added to handle real-time updates, ensuring all users immediately see the updated claim status.

Codebase Findings
- The code is essentially a standard web app that uses client calls for buttons or changes to the UI to access the server-side API.
- Any handling done by the user side provokes a WebSocket to handle any changes to other users and is used here to update other clients of the changed button.

Potential Features
- The button could be locked with middleware to restrict access to authenticated TAs (`middleware.ensureLoggedIn and middleware.isTA`)